### PR TITLE
Add Support for Custom Prompts and Refactor Prompt Management - Reworked

### DIFF
--- a/llmcompiler/chat/launch.py
+++ b/llmcompiler/chat/launch.py
@@ -77,7 +77,7 @@ class Launch(ABC):
 
         self.rewrite = Rewrite(llm=llm, tools=tools, few_shot=few_shot, custom_prompts=custom_prompts)
         if self.swi_planer:
-            self.plan_and_schedule = PlanAndSchedule(self.swi_planer, self.tools, self.swi_re_planer, self.print_dag)
+            self.plan_and_schedule = PlanAndSchedule(self.swi_planer, self.tools, self.swi_re_planer, self.print_dag, self.custom_prompts)
         else:
             raise Exception("Planer is not initialized!")
 

--- a/llmcompiler/chat/launch.py
+++ b/llmcompiler/chat/launch.py
@@ -13,6 +13,7 @@ from langchain_core.messages import ChatMessage
 from langchain_core.tools import BaseTool
 from langgraph.constants import END
 from langgraph.graph.graph import CompiledGraph
+from langchain.prompts import PromptTemplate
 
 from llmcompiler.few_shot.few_shot import BaseFewShot
 from llmcompiler.graph.output_parser import Task
@@ -38,7 +39,8 @@ class Launch(ABC):
                  joiner: Union[BaseLanguageModel, List[BaseLanguageModel], SwitchLLM, List[SwitchLLM]] = None,
                  re_planer: Union[BaseLanguageModel, List[BaseLanguageModel], SwitchLLM, List[SwitchLLM]] = None,
                  multi_dialogue: bool = False, debug_prompt: bool = False, few_shot: BaseFewShot = None,
-                 print_graph: bool = True, print_dag: bool = True):
+                 print_graph: bool = True, print_dag: bool = True,
+                 custom_prompts: dict[str, str] = None):
         """
         初始化必要参数。
         :param chat: 请求对象
@@ -51,11 +53,13 @@ class Launch(ABC):
         :param few_shot: Few-shot对象。
         :param print_graph: LLMCompiler的LangGrap结构可视化语法是否打印。
         :param print_dag: 任务的有向无环图可视化语法是否打印。
+        :param custom_prompts: 自定义提示词。
         """
         self.few_shot = few_shot
         self.chat = chat
         self.multi_dialogue = multi_dialogue
         self.debug_prompt = debug_prompt
+        self.custom_prompts = custom_prompts
 
         self.swi_re_planer = None
         self.swi_joiner = None
@@ -71,7 +75,7 @@ class Launch(ABC):
         self.print_graph = print_graph
         self.print_dag = print_dag
 
-        self.rewrite = Rewrite(llm=llm, tools=tools, few_shot=few_shot)
+        self.rewrite = Rewrite(llm=llm, tools=tools, few_shot=few_shot, custom_prompts=custom_prompts)
         if self.swi_planer:
             self.plan_and_schedule = PlanAndSchedule(self.swi_planer, self.tools, self.swi_re_planer, self.print_dag)
         else:

--- a/llmcompiler/chat/run.py
+++ b/llmcompiler/chat/run.py
@@ -32,7 +32,7 @@ class RunLLMCompiler(Launch):
         start_time = time.time()
         graph_builder = MessageGraph()
         graph_builder.add_node("plan_and_schedule", self.plan_and_schedule.init)
-        graph_builder.add_node("join", Joiner(self.swi_joiner, self.tools, self.chat.message).init)
+        graph_builder.add_node("join", Joiner(self.swi_joiner, self.tools, self.chat.message, self.custom_prompts).init)
         graph_builder.set_entry_point("plan_and_schedule")
         graph_builder.add_edge("plan_and_schedule", "join")
         graph_builder.add_conditional_edges(

--- a/llmcompiler/graph/joiner.py
+++ b/llmcompiler/graph/joiner.py
@@ -26,6 +26,7 @@ from langchain_core.messages import (
 
 from llmcompiler.graph.prompt import JOINER_SYSTEM_PROMPT_1, JOINER_SYSTEM_PROMPT_2, JOINER_RESPONSE_HUMAN_TEMPLATE
 from llmcompiler.utils.date.date import formatted_dt_now
+from llmcompiler.utils.prompt.prompt import get_custom_or_default
 from llmcompiler.utils.string.question_trim import extract_json_dict
 from llmcompiler.graph.token_calculate import SwitchLLM, auto_switch_llm
 
@@ -62,8 +63,8 @@ class Joiner:
         self.custom_prompts = custom_prompts
 
     def init(self, messages: list):
-        joiner_system_prompt_1 = self.custom_prompts["JOINER_SYSTEM_PROMPT_1"] if self.custom_prompts and "JOINER_SYSTEM_PROMPT_1" in self.custom_prompts else JOINER_SYSTEM_PROMPT_1
-        joiner_system_prompt_2 = self.custom_prompts["JOINER_SYSTEM_PROMPT_2"] if self.custom_prompts and "JOINER_SYSTEM_PROMPT_2" in self.custom_prompts else JOINER_SYSTEM_PROMPT_2
+        joiner_system_prompt_1 = get_custom_or_default(self.custom_prompts, "JOINER_SYSTEM_PROMPT_1", JOINER_SYSTEM_PROMPT_1)
+        joiner_system_prompt_2 = get_custom_or_default(self.custom_prompts, "JOINER_SYSTEM_PROMPT_2", JOINER_SYSTEM_PROMPT_2)
         PROMPT = ChatPromptTemplate.from_messages(
             [
                 SystemMessagePromptTemplate(
@@ -107,7 +108,7 @@ class Joiner:
         """
         指定Joiner阶段固定的用户消息模板
         """
-        joiner_response_human_template = self.custom_prompts["JOINER_RESPONSE_HUMAN_TEMPLATE"] if self.custom_prompts and "JOINER_RESPONSE_HUMAN_TEMPLATE" in self.custom_prompts else JOINER_RESPONSE_HUMAN_TEMPLATE
+        joiner_response_human_template = get_custom_or_default(self.custom_prompts, "JOINER_RESPONSE_HUMAN_TEMPLATE", JOINER_RESPONSE_HUMAN_TEMPLATE)
         REWRITE_INFO_PROMPT = PromptTemplate.from_template(joiner_response_human_template)
         new_message = REWRITE_INFO_PROMPT.format(question=self.question)
         return new_message

--- a/llmcompiler/graph/plan_and_schedule.py
+++ b/llmcompiler/graph/plan_and_schedule.py
@@ -678,7 +678,8 @@ class PlanAndSchedule:
     """
 
     def __init__(self, llm: Union[SwitchLLM, List[SwitchLLM]], tools: Sequence[BaseTool],
-                 re_llm: Union[SwitchLLM, List[SwitchLLM]] = None, print_dag: bool = True):
+                 re_llm: Union[SwitchLLM, List[SwitchLLM]] = None, print_dag: bool = True,
+                 custom_prompts: dict[str, str] = None):
         self.llm = llm
         self.re_llm = re_llm
         self.tools = tools
@@ -686,10 +687,11 @@ class PlanAndSchedule:
         self.tasks_temporary_save = []
         self.observations = {}  # Save all previous tool responses
         self.print_dag = print_dag
+        self.custom_prompts = custom_prompts
 
     # @as_runnable
     def init(self, messages: List[BaseMessage], config):
-        planner = Planer(self.llm, self.tools, self.re_llm).init()
+        planner = Planer(self.llm, self.tools, self.re_llm, self.custom_prompts).init()
         tasks = planner.stream(messages, config)
         # Begin executing the planner immediately
         try:

--- a/llmcompiler/graph/prompt.py
+++ b/llmcompiler/graph/prompt.py
@@ -4,6 +4,9 @@
 @Desc    : LLMCompiler
 @Time    : 2024-08-02 09:30:49
 """
+from llmcompiler.utils.date.date import formatted_dt_now
+
+
 PLANER_SYSTEM_PROMPT_1 = """Given a user query, create a plan to solve it with the utmost parallelizability. Each plan should comprise an action from the following {num_tools} types:
 {tool_descriptions}
 {num_tools}. join(): Collects and combines results from prior actions.
@@ -128,3 +131,42 @@ JOINER_RESPONSE_HUMAN_TEMPLATE = """请基于用户问题，和给出的数据�
 {question}
 
 Let’s think step by step!"""
+
+
+SYSTEM_TEMPLATE = f"""你是由易方达基金创造的金融领域专家同时精通自然语言处理NLP技术，而且非常擅长使用工具解决问题。
+你可以基于用户问题、相关信息、参考计划、可选工具、备注说明，生成一个专业且简洁的找数据的最少执行计划。
+你的目标是遵循备注说明的内容，在不改变原有用户问题含义的情况下对用户问题生成执行计划。
+"""
+
+HUMAN_TEMPLATE = f"""**用户问题**
+{{question}}
+
+**相关信息**
+{{info}}
+
+**参考计划**
+{{examples}}
+
+**可选工具**
+{{tools}}
+
+**备注说明**
+生成计划时需要详细列出要查找哪些数据，每个计划的开头一般都是`查找`，结尾一般需要列出可以使用的工具，备选工具已经在**可选工具**中列出，使用工具时可能需要一些必要参数请将这些参数列出来。
+生成计划时请充分参考相关信息中列出的内容，确保每个计划都补充了上下文信息，不要有冗余的执行计划。
+特别要注意如果相关信息中有基金代码需要补充到生成的执行计划中。
+现在的时间是：{formatted_dt_now()}，执行计划中的时间词注意替换为具体时间。
+相关信息中可能包含除了时间信息外一些其它重要内容，你可以充分利用。
+闲聊类问题不需要给出执行计划。
+不要说出需要使用哪些找数据工具、数据源、第三方平台工具、查找官网等等信息。
+不要说出任何抱歉、对不起、根据提供的信息等等与找数据没关系的语句。
+不需要尝试回答问题，也不要给出任何分析后的结果。
+最终的响应内容包含<用户问题>、<执行计划>两项即可。
+去掉用户问题中关于结果形式的描述。
+
+Let’s think step by step!"""
+
+
+RESPONSE_PLAN_FORMAT_PREFIX = """下面列出了解决用户问题需要参考的执行计划，请充分参考执行计划的步骤生成`Plan`。
+"""
+
+RESPONSE_PLAN_FORMAT_SUFFIX = """\nLet’s think step by step!"""

--- a/llmcompiler/graph/prompt.py
+++ b/llmcompiler/graph/prompt.py
@@ -4,7 +4,6 @@
 @Desc    : LLMCompiler
 @Time    : 2024-08-02 09:30:49
 """
-from llmcompiler.utils.date.date import formatted_dt_now
 
 
 PLANER_SYSTEM_PROMPT_1 = """Given a user query, create a plan to solve it with the utmost parallelizability. Each plan should comprise an action from the following {num_tools} types:
@@ -138,23 +137,23 @@ SYSTEM_TEMPLATE = f"""你是由易方达基金创造的金融领域专家同时�
 你的目标是遵循备注说明的内容，在不改变原有用户问题含义的情况下对用户问题生成执行计划。
 """
 
-HUMAN_TEMPLATE = f"""**用户问题**
-{{question}}
+HUMAN_TEMPLATE = """**用户问题**
+{question}
 
 **相关信息**
-{{info}}
+{info}
 
 **参考计划**
-{{examples}}
+{examples}
 
 **可选工具**
-{{tools}}
+{tools}
 
 **备注说明**
 生成计划时需要详细列出要查找哪些数据，每个计划的开头一般都是`查找`，结尾一般需要列出可以使用的工具，备选工具已经在**可选工具**中列出，使用工具时可能需要一些必要参数请将这些参数列出来。
 生成计划时请充分参考相关信息中列出的内容，确保每个计划都补充了上下文信息，不要有冗余的执行计划。
 特别要注意如果相关信息中有基金代码需要补充到生成的执行计划中。
-现在的时间是：{formatted_dt_now()}，执行计划中的时间词注意替换为具体时间。
+现在的时间是：{formatted_dt_now}，执行计划中的时间词注意替换为具体时间。
 相关信息中可能包含除了时间信息外一些其它重要内容，你可以充分利用。
 闲聊类问题不需要给出执行计划。
 不要说出需要使用哪些找数据工具、数据源、第三方平台工具、查找官网等等信息。

--- a/llmcompiler/graph/rewrite.py
+++ b/llmcompiler/graph/rewrite.py
@@ -106,7 +106,7 @@ REWRITE_PROMPT = ChatPromptTemplate.from_messages(
         SystemMessagePromptTemplate(
             prompt=PromptTemplate(input_variables=[], template=SYSTEM_TEMPLATE)),
         HumanMessagePromptTemplate(
-            prompt=PromptTemplate(input_variables=["question"],
+            prompt=PromptTemplate(input_variables=["date", "question"],
                                   template=HUMAN_TEMPLATE).partial(formatted_dt_now=formatted_dt_now())
         )
     ]

--- a/llmcompiler/utils/prompt/prompt.py
+++ b/llmcompiler/utils/prompt/prompt.py
@@ -1,0 +1,5 @@
+
+
+def get_custom_or_default(custom_prompts: dict[str, str], key: str, default_value: str) -> str:
+    """Helper function to return custom prompt if available, otherwise default."""
+    return custom_prompts[key] if custom_prompts and key in custom_prompts else default_value

--- a/test/test_custom_prompts.py
+++ b/test/test_custom_prompts.py
@@ -1,0 +1,68 @@
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from llmcompiler.tools.basic import Tools
+from llmcompiler.result.chat import ChatRequest
+from langchain_openai.chat_models.base import ChatOpenAI
+from llmcompiler.chat.run import RunLLMCompiler
+from langchain.prompts import PromptTemplate
+
+# chat = ChatRequest(message="How has the return been for Tech stocks since their inception?")
+# tools = Tools.load_tools(["../llmcompiler/tools/basetool/stock_info_fake.py",
+#                           "../llmcompiler/tools/basetool/multi_param_dep_v1.py"])
+
+chat = ChatRequest(
+    message="How has the return been for Tech stocks since their inception?"
+)
+tools = Tools.load_tools(
+    [
+        "../llmcompiler/tools/basetool/stock_info_fake.py",
+        "../llmcompiler/tools/basetool/multi_param_dep_v2.py",
+    ]
+)
+
+# chat = ChatRequest(
+#     message="How has the return been for Tech stocks since their inception? Calculate the average return of tech stocks.")
+# tools = Tools.load_tools(["../llmcompiler/tools/math",
+#                           "../llmcompiler/tools/basetool/stock_info_fake.py",
+#                           "../llmcompiler/tools/basetool/multi_param_dep_v3.py"])
+
+print(tools)
+
+llm = ChatOpenAI(model="gpt-4o", temperature=0, max_retries=3)
+
+custom_prompts = {
+    "JOINER_RESPONSE_HUMAN_TEMPLATE": """Please generate the Final Answer that the user needs based on the user's question and the provided data, ensuring it is logical and rigorous.
+
+When generating the Final Answer, it's important to carefully check the accuracy of any numerical content and ensure that the data provided is relevant to the user's question. The Final Answer can be a few concise summary sentences, but it must fully address the user's question. If numerical analysis is required in the Final Answer, try to analyze information such as the maximum value, minimum value, and data trends after carefully understanding the data fields.
+
+The Final Answer should not contain any formatting or large blocks of numerical content. Remember, the final response to the user should follow one of the options in the RESPONSE FORMAT INSTRUCTIONS, and the output should comply with those requirements.
+
+**User Question**
+{question}
+
+Let’s think step by step!""",
+    "HUMAN_MESSAGE_TEMPLATE": """Please generate a professional and concise minimum execution plan based on the user's question, along with the relevant information and reference plans.
+
+The relevant information may contain some related data that can be used as "constants." When generating the "Plan," please carefully check the information provided. However, remember not to create any "constant" information not provided in the user's question or the relevant information. For example, if a fund code is not provided, it must be queried using a Tool—this is important.
+
+**User Question**
+{question}
+
+**Relevant Information**
+{info}
+
+**Reference Plan**
+{examples}
+
+Let’s think step by step!
+""",
+    "JOINER_SYSTEM_PROMPT_2": """Using the above previous actions, decide whether to replan or finish. If all the required information is present. You may finish. If you have made many attempts to find the information without success, admit so and respond with whatever information you have gathered so the user can work well with you.The response should be in English.""",
+}
+
+# llm_compiler = RunLLMCompiler(chat, tools, llm, custom_prompts)
+llm_compiler = RunLLMCompiler(chat=chat, tools=tools, llm=llm, custom_prompts=custom_prompts)
+print(llm_compiler())
+
+# llm_compiler.runWithoutJoiner()


### PR DESCRIPTION
## Updated Description
- Moved `formatted_dt_now` (`HUMAN_TEMPLATE`) formatting to `rewrite.py` to avoid the issue of  this value being assigned in `prompt.py`
- Added more custom prompts:
  - `PLANER_SYSTEM_PROMPT_1`
  - `PLANER_SYSTEM_PROMPT_2`
- Minor Refactor with `get_custom_or_default` function

Feel free to let me know if that solved the issue you mentioned :)

## Previous Description
This PR introduces support for custom prompts that can overwrite predefined prompts, addressing the issue of some prompts being in Chinese only. The following updates have been made:

- Custom Prompt Support:
  - Added functionality to allow users to pass custom prompts, which can overwrite the predefined ones. This is particularly useful for choosing language and adjusting the behavior.

- New Tests:
  - Added a new test file tests/test_custom_prompts.py which demonstrates how custom prompts can be passed and tested.

- Refactoring and Consolidation of Prompts:
  - Moved some predefined prompts into a new file prompt.py for better organization and maintainability.
  - Currently, only the following prompts are supported for customization:
    - `JOINER_SYSTEM_PROMPT_1`
    - `JOINER_SYSTEM_PROMPT_2`
    - `HUMAN_MESSAGE_TEMPLATE`
    - `JOINER_RESPONSE_HUMAN_TEMPLATE`

-  Open Points:
   - Only a subset of prompts is currently supported for customization, as it's unclear which additional prompts are actively used, can be removed, or will be needed in the future. Feedback on which additional prompts should be supported is welcome.

Request for Feedback:
- Suggestions for additional prompts to support or remove.
- Maybe add general overhaul of how the Prompts/Templates are defined?

Awesome project! :)